### PR TITLE
Create example providers after make configure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
         git config --add user.name github_actions
         git config --add user.email actions_noreply@github.com
         make configure
+        make tfmodule/create_example_providers
 
     - name: Lint Repository
       shell: bash


### PR DESCRIPTION
Resolves an issue with TF modules that use an aliased provider rather than the default provider.

To accommodate these modules, the calling module (usually our example module) has to pass its global provider alias (for AWS us-east-1-only resources like WAF) to the called module (the root). This provider alias doesn't exist until the example provider files are laid down, so we need to execute that target prior to lint.