### PR TITLE
Run init after configure until #298 is resolved

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
         git config --add user.name github_actions
         git config --add user.email actions_noreply@github.com
         make configure
+        make tfmodule/init
         make tfmodule/create_example_providers
 
     - name: Lint Repository


### PR DESCRIPTION
Mitigates the go/lint target not running a TF init first.